### PR TITLE
No peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/taskcluster/taskcluster-lib-rules/issues"
   },
   "homepage": "https://github.com/taskcluster/taskcluster-lib-rules#readme",
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^1.9.0",
     "babel-plugin-syntax-async-functions": "^6.1.18",
     "babel-plugin-transform-async-to-module-method": "^6.1.18",
@@ -24,9 +24,7 @@
     "babel-plugin-transform-runtime": "^6.1.18",
     "babel-preset-stage-1": "^6.1.18",
     "babel-preset-es2015": "^6.1.18",
-    "babel-eslint": "^4.1.5"
-  },
-  "dependencies": {
+    "babel-eslint": "^4.1.5",
     "install": "^0.3.0",
     "npm": "^3.4.0"
   }


### PR DESCRIPTION
Is there really any reason to make this peerDependencies... Parent projects are not going to use these dependencies...

I'm not entirely sure when `peerDependencies` are preferred. I think it's mostly for cases where you want to parent to decide what version of the library the child should use. Mostly relevant in cases where child and parent use the same library.

Example: parent creates an instance of 3rd party library object, and hands this instance over to child library that then uses 3rd party library to modify the instance. In this case both parent and child have to use the same library version.

A practical example we have is `babel-compile` where `babel-compile` should use the same `babel-core` version as the parent uses for `babel-runtime`. Hence, making `babel-core` a peer dependency makes sense.

In this case it just seems to perhaps defeat the point... Ie. I view the point of `tc-rules` to be that parents don't have to remember config. But with versions being specified by the parent, then the parent does hold config.

---

Unrelated, I'm tempted to suggest we only have one babel file... but see we need a babel-node5 file for that special case...

Hmm... Couldn't we just detect node-version before we set module.exports in that file? :)
