### PR TITLE
No more peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-rules",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Rules shared by tools used by taskcluster",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
     "url": "https://github.com/taskcluster/taskcluster-lib-rules/issues"
   },
   "homepage": "https://github.com/taskcluster/taskcluster-lib-rules#readme",
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^1.9.0",
     "babel-plugin-syntax-async-functions": "^6.1.18",
     "babel-plugin-transform-async-to-module-method": "^6.1.18",
@@ -24,9 +24,7 @@
     "babel-plugin-transform-runtime": "^6.1.18",
     "babel-preset-stage-1": "^6.1.18",
     "babel-preset-es2015": "^6.1.18",
-    "babel-eslint": "^4.1.5"
-  },
-  "dependencies": {
+    "babel-eslint": "^4.1.5",
     "install": "^0.3.0",
     "npm": "^3.4.0"
   }


### PR DESCRIPTION
They don't work great with node5... besides tc-rules is always a devDependency downstream...

@jhford, do you see any reason not to just use:

``` js
module.exports = {
  presets: [
    'es2015'
  ],
  plugins: [
    'syntax-async-functions',
    'transform-regenerator',
    'transform-runtime',
  ]
};
```

And bump version to 3.0.0 and drop support for babel 5... As well as exporting it from `index.js` so we don't have to do `tc-rules/babel6`

@jhford rather than having `babel-node5.js` I propose that we have, a strategy:
 1) Read package.json from cwd, if it specifies node version we use that,
 2) otherwise rely on node version from the process object.
Based on detected node version we do: `transform-async-to-generator` or `transform-regenerator`.

Or we create a file, called 5.js and 4.js, so it's just `tc-rules/5` and `tc-rules/6` respectively...

Thoughts?
