### PR TITLE
fix broken configuration

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -5,6 +5,7 @@ module.exports = {
   plugins: [
     'syntax-async-functions',
     'transform-runtime',
+    'transform-async-to-generator',
     'transform-strict-mode',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-rules",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Rules shared by tools used by taskcluster",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
the syntax-\* modules just parse js, but you never actually did the transformations to use something other than async...

We could theoretically also use bluebird, but i'd just like something that works for the time being.
