### PR TITLE
Add array includes plugin to the rules

### DIFF
--- a/babel-node5.js
+++ b/babel-node5.js
@@ -3,6 +3,7 @@ module.exports = {
     "node5"
   ],
   "plugins": [
+    "array-includes",
     "syntax-async-functions",
     "transform-async-to-generator"
   ]

--- a/babel.js
+++ b/babel.js
@@ -3,10 +3,11 @@ module.exports = {
     'es2015',
   ],
   plugins: [
+    'array-includes',
     'syntax-async-functions',
+    'syntax-trailing-function-commas',
     'transform-runtime',
     'transform-async-to-generator',
     'transform-strict-mode',
-    'syntax-trailing-function-commas'
   ],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-rules",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Rules shared by tools used by taskcluster",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/taskcluster/taskcluster-lib-rules#readme",
   "dependencies": {
     "babel-eslint": "^5.0.0",
+    "babel-plugin-array-includes": "^2.0.0",
     "babel-plugin-syntax-async-functions": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-plugin-transform-strict-mode": "^6.0.0",


### PR DESCRIPTION
I _think_ this is what's necessary to get this plugin enabled.

Allows us to do something like 
[1,2,3,4].includes(4) instead of [1,2,3,4].indexOf(4) !== -1
